### PR TITLE
More DRY, more lazy

### DIFF
--- a/loxun.py
+++ b/loxun.py
@@ -1085,6 +1085,7 @@ class XmlWriter(object):
             self._possiblyFlushTag()
             self._possiblyWriteTag(namespace, name, XmlWriter._CLOSE_AT_START)
 
+
     def endTags(self, count=0):
         """
         End tags is useful if you need to close a couple of tags in one command
@@ -1140,7 +1141,7 @@ class XmlWriter(object):
         
         for i in xrange(count):
             self.endTag()
-
+            
     def tag(self, qualifiedName, attributes={}):
         self._possiblyFlushTag()
         uniQualifiedName = self._unicodedFromString(qualifiedName)
@@ -1199,6 +1200,7 @@ class XmlWriter(object):
                 self.newline()
         else:
             self._writeEscaped(uniText)
+
 
     def comment(self, text, embedInBlanks=True):
         """
@@ -1270,6 +1272,7 @@ class XmlWriter(object):
         self._write(u"-->");
         if self._pretty:
             self.newline()
+
 
     def cdata(self, text):
         """
@@ -1399,7 +1402,53 @@ class XmlWriter(object):
         if remainingElements:
             raise XmlError(u"missing end tags must be added: %s" % remainingElements)
 
+
+class ChainXmlWriter(XmlWriter):
+    """
+    XmlWriter-wrapper for method chaining, here is an example:
+        >>> from StringIO import StringIO
+        >>> out = StringIO()
+        >>> xml = ChainXmlWriter(out)
+        >>> xml.addNamespace("xhtml", "http://www.w3.org/1999/xhtml") #doctest: +ELLIPSIS
+        <loxun.ChainXmlWriter object at 0x...>
+        >>> xml.startTag("xhtml:html").startTag("xhtml:body") #doctest: +ELLIPSIS
+        <loxun.ChainXmlWriter object at 0x...>
+        >>> xml.text("Hello world!").tag("xhtml:img", {"src": "smile.png", "alt": ":-)"}) #doctest: +ELLIPSIS
+        <loxun.ChainXmlWriter object at 0x...>
+        >>> xml.endTags().close()
+
+    And the result is:
+
+        >>> print out.getvalue().rstrip("\\r\\n")
+        <?xml version="1.0" encoding="utf-8"?>
+        <xhtml:html xmlns:xhtml="http://www.w3.org/1999/xhtml">
+          <xhtml:body>
+            Hello world!
+            <xhtml:img alt=":-)" src="smile.png" />
+          </xhtml:body>
+        </xhtml:html>
+    """
+
+    chainableMethods = ('addNamespace', 'cdata', 'comment', 'endTag',
+                        'endTags', 'processingInstruction', 'startTag', 'tag',
+                        'text',)
+
+    def _chainDecorator(self, func):
+        def _wrapper(*args, **kwargs):
+            func(*args, **kwargs)
+            return self
+        return _wrapper
+
+    def __getattribute__(self, name):
+
+        if name in ChainXmlWriter.chainableMethods:
+            originalMethod = getattr(super(ChainXmlWriter, self), name)
+            return self._chainDecorator(originalMethod)
+
+        return super(ChainXmlWriter, self).__getattribute__(name)
+
 if __name__ == "__main__":
     import doctest
     print "loxun %s: running doctest" % __version__
     doctest.testmod()
+


### PR DESCRIPTION
1. Feature to end a few tags in one method call (see endTags)
2. ChainXmlWriter implements method chaining - makes code look better.

doctests are applied. 
