### PR TITLE
Use of `xml` namespace and trimmed Text/CDATA nodes.

### DIFF
--- a/loxun.py
+++ b/loxun.py
@@ -865,9 +865,10 @@ class XmlWriter(object):
             raise XmlError("operation must be performed before writer is closed")
 
     def _validateNamespaceItem(self, itemName, namespace, qualifiedName):
-        if namespace:
+        if namespace and namespace != 'xml':
             namespaceFound = False
             scopeIndex = self._scope()
+
             while not namespaceFound and (scopeIndex >= 0):
                 namespacesForScope = self._namespaces.get(scopeIndex)
                 if namespacesForScope:


### PR DESCRIPTION
To solve the #8 and add the option `prettyText` to use when is needed to have a readable XML with  trimmed Text/CDATA nodes.